### PR TITLE
Rename `wasm_interop` to `ts_interop`

### DIFF
--- a/game-core/Cargo.lock
+++ b/game-core/Cargo.lock
@@ -40,9 +40,9 @@ name = "game"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "ts-interop",
  "tsify",
  "wasm-bindgen",
- "wasm-interop",
 ]
 
 [[package]]
@@ -135,6 +135,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "ts-interop"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -233,14 +241,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
-
-[[package]]
-name = "wasm-interop"
-version = "0.1.0"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "web-sys"

--- a/game-core/Cargo.toml
+++ b/game-core/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["game", "wasm", "wasm-interop"]
+members = ["game", "wasm", "ts-interop"]

--- a/game-core/game/Cargo.toml
+++ b/game-core/game/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tsify =  { version = "0.4", optional = true, default-features = false, features = ["js"] }
+ts-interop = { path = "../ts-interop" }
 wasm-bindgen = { version = "0.2", optional = true }
-wasm-interop = { path = "../wasm-interop" }
 
 
 [features]

--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -1,8 +1,8 @@
 use crate::tile::{FreeTile, Tile};
-use wasm_interop::wasm_interop;
+use ts_interop::ts_interop;
 
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub struct Board {
     tiles: Vec<Tile>,
     side_length: usize,

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -1,5 +1,5 @@
 use tsify::declare;
-use wasm_interop::wasm_interop;
+use ts_interop::ts_interop;
 
 use crate::tile::Item;
 
@@ -7,7 +7,7 @@ use crate::tile::Item;
 pub type PlayerId = u8;
 
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub struct Player {
     id: PlayerId,
     position: Position,
@@ -17,7 +17,7 @@ pub struct Player {
 }
 
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub struct Position {
     x: usize,
     y: usize,

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -1,8 +1,8 @@
 use std::num::NonZeroU8;
-use wasm_interop::wasm_interop;
+use ts_interop::ts_interop;
 
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub struct Tile {
     id: u32,
     variant: TileVariant,
@@ -29,11 +29,11 @@ pub enum Rotation {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[wasm_interop]
+#[ts_interop]
 pub struct Item(#[cfg_attr(feature = "wasm", tsify(type = "number"))] NonZeroU8);
 
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub struct FreeTile {
     tile: Tile,
     side_with_index: Option<(Side, usize)>,
@@ -42,7 +42,7 @@ pub struct FreeTile {
 /// The side of the board where the free tile is located.
 /// The index always goes from left to right or from top to bottom.
 #[derive(Clone)]
-#[wasm_interop]
+#[ts_interop]
 pub enum Side {
     Top,
     Right,

--- a/game-core/ts-interop/Cargo.toml
+++ b/game-core/ts-interop/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wasm-interop"
+name = "ts-interop"
 version = "0.1.0"
 edition = "2021"
 

--- a/game-core/ts-interop/src/lib.rs
+++ b/game-core/ts-interop/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 #[proc_macro_attribute]
-pub fn wasm_interop(_: TokenStream, item: TokenStream) -> TokenStream {
+pub fn ts_interop(_: TokenStream, item: TokenStream) -> TokenStream {
     let item: proc_macro2::TokenStream = item.into();
     quote! {
     #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
This PR renames `wasm_interop` to `ts_interop` to better reflect the functionality of the macro.