### PR TITLE
Implement `Board::new`

### DIFF
--- a/game-core/Cargo.lock
+++ b/game-core/Cargo.lock
@@ -39,9 +39,24 @@ dependencies = [
 name = "game"
 version = "0.1.0"
 dependencies = [
+ "getrandom",
+ "rand",
  "serde",
  "ts-interop",
  "tsify",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -55,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +86,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -82,6 +109,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -174,6 +231,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm"

--- a/game-core/Cargo.toml
+++ b/game-core/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["game", "wasm", "ts-interop"]
+members = ["game", "ts-interop", "wasm"]

--- a/game-core/game/Cargo.toml
+++ b/game-core/game/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
 getrandom = { version = "0.2", features = ["js"] }
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 tsify =  { version = "0.4", optional = true, default-features = false, features = ["js"] }
 ts-interop = { path = "../ts-interop" }

--- a/game-core/game/Cargo.toml
+++ b/game-core/game/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "0.8.5"
+getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0", features = ["derive"] }
 tsify =  { version = "0.4", optional = true, default-features = false, features = ["js"] }
 ts-interop = { path = "../ts-interop" }

--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -1,6 +1,9 @@
+use std::iter;
+
+use rand::seq::{IteratorRandom, SliceRandom};
 use ts_interop::ts_interop;
 
-use crate::tile::{FreeTile, Tile};
+use crate::tile::{FreeTile, Item, Rotation, Tile, TileVariant};
 
 #[ts_interop]
 #[derive(Clone)]
@@ -8,4 +11,106 @@ pub struct Board {
     tiles: Vec<Tile>,
     side_length: usize,
     free_tile: FreeTile,
+}
+
+impl Board {
+    pub fn new(side_length: usize) -> Self {
+        assert!(side_length % 2 == 1 && side_length > 2);
+        use Rotation::*;
+        use TileVariant::*;
+
+        let rotations = [Ninety, TwoSeventy, Zero, OneEighty];
+
+        let mut tiles = Vec::with_capacity(side_length.pow(2));
+        let mut movable_tiles = get_tile_assortment(side_length);
+
+        let mut rng = rand::thread_rng();
+        movable_tiles.shuffle(&mut rng);
+
+        let num_movable_items = calculate_number_of_items(side_length) / 2;
+        let movable_item_indices =
+            (0..movable_tiles.len()).choose_multiple(&mut rng, num_movable_items);
+
+        let mut index = 0;
+        let mut item_id = 0;
+        for row in 0..side_length {
+            for col in 0..side_length {
+                let (variant, rotation, add_item) = match (row, col) {
+                    // Corners
+                    (0, 0) => (LShape, Ninety, false),
+                    (0, c) if c == side_length - 1 => (LShape, OneEighty, false),
+                    (r, 0) if r == side_length - 1 => (LShape, Zero, false),
+                    (r, c) if r == side_length - 1 && r == c => (LShape, TwoSeventy, false),
+                    // Sides
+                    (r, c) if r == 0 && c % 2 == 0 => (TShape, Zero, true),
+                    (r, c) if c == 0 && r % 2 == 0 => (TShape, TwoSeventy, true),
+                    (r, c) if r == side_length - 1 && c % 2 == 0 => (TShape, OneEighty, true),
+                    (r, c) if c == side_length - 1 && r % 2 == 0 => (TShape, Ninety, true),
+                    // Inners
+                    (r, c) if r % 2 == 0 && c % 2 == 0 => {
+                        index = (index + 1) % rotations.len();
+                        (TShape, rotations[index], true)
+                    }
+                    // Movables
+                    _ => (
+                        movable_tiles.pop().unwrap(),
+                        *rotations.choose(&mut rng).unwrap(),
+                        movable_item_indices.contains(&movable_tiles.len()),
+                    ),
+                };
+
+                let item = if add_item {
+                    item_id += 1;
+                    Some(Item::new(item_id))
+                } else {
+                    None
+                };
+
+                tiles.push(Tile::new(row * side_length + col, variant, rotation, item));
+            }
+        }
+
+        let free_tile = movable_tiles.pop().unwrap();
+        assert!(movable_tiles.is_empty());
+        let item = if movable_item_indices.contains(&0) {
+            Some(Item::new(item_id + 1))
+        } else {
+            None
+        };
+        let free_tile = FreeTile::new(Tile::new(side_length.pow(2), free_tile, Zero, item));
+
+        Self {
+            tiles,
+            side_length,
+            free_tile,
+        }
+    }
+}
+
+fn get_tile_assortment(side_length: usize) -> Vec<TileVariant> {
+    const T_RATIO: f64 = 6. / 34.;
+    const I_RATIO: f64 = 13. / 34.;
+    const L_RATIO: f64 = 15. / 34.;
+
+    let num_moveable = side_length.pow(2) - (side_length / 2 + 1).pow(2) + 1;
+    let num_t_tiles = (num_moveable as f64 * T_RATIO) as usize; // flooring
+    let num_i_tiles = (num_moveable as f64 * I_RATIO) as usize;
+    let mut num_l_tiles = (num_moveable as f64 * L_RATIO) as usize;
+
+    if num_t_tiles + num_i_tiles + num_l_tiles != num_moveable {
+        num_l_tiles += 1;
+    }
+    assert!(num_t_tiles + num_i_tiles + num_l_tiles == num_moveable);
+
+    let mut movable_tiles = Vec::with_capacity(num_moveable);
+    movable_tiles.extend(iter::repeat(TileVariant::TShape).take(num_t_tiles));
+    movable_tiles.extend(iter::repeat(TileVariant::IShape).take(num_i_tiles));
+    movable_tiles.extend(iter::repeat(TileVariant::LShape).take(num_l_tiles));
+
+    movable_tiles
+}
+
+fn calculate_number_of_items(side_length: usize) -> usize {
+    // 2 * (ceil(side_length / 2)² - num_corners)
+    2 * ((side_length / 2 + 1).pow(2) - 4)
 }

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -2,3 +2,13 @@ pub mod board;
 pub mod game;
 pub mod player;
 pub mod tile;
+
+#[cfg(test)]
+mod tests {
+    use crate::board::Board;
+
+    #[test]
+    fn it_works() {
+        Board::new(0, 7);
+    }
+}

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
     use crate::board::Board;
 
     #[test]
-    fn it_works() {
-        Board::new(0, 7);
+    fn new_board() {
+        Board::new(7);
     }
 }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -69,3 +69,31 @@ pub enum Side {
     Bottom,
     Left,
 }
+
+impl Tile {
+    pub fn new(id: usize, variant: TileVariant, rotation: Rotation, item: Option<Item>) -> Self {
+        Self {
+            id,
+            variant,
+            rotation,
+            item,
+        }
+    }
+}
+
+impl Item {
+    pub fn new(id: usize) -> Self {
+        assert!(id != 0);
+        // Safety: id != 0
+        Self(unsafe { NonZeroUsize::new_unchecked(id) })
+    }
+}
+
+impl FreeTile {
+    pub fn new(tile: Tile) -> Self {
+        Self {
+            tile,
+            side_with_index: None,
+        }
+    }
+}

--- a/game-core/ts-interop/Cargo.toml
+++ b/game-core/ts-interop/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quote = "1.0.35"
 proc-macro2 = "1.0.78"
+quote = "1.0.35"
 
 [lib]
 proc-macro = true

--- a/game-core/wasm/Cargo.toml
+++ b/game-core/wasm/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2"
 console_error_panic_hook = { version = "0.1" }
-log = "0.4"
 console_log = { version = "1", features = ["color"] }
 game = { path = "../game", features = ["wasm"] }
+log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.5"
+wasm-bindgen = "0.2"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,14 +1,21 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
-  "compilerOptions": {
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
+    "extends": "@vue/tsconfig/tsconfig.dom.json",
+    "include": [
+        "env.d.ts",
+        "src/**/*",
+        "src/**/*.vue"
+    ],
+    "exclude": [
+        "src/**/__tests__/*"
+    ],
+    "compilerOptions": {
+        "composite": true,
+        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": [
+                "./src/*"
+            ]
+        }
     }
-  }
 }


### PR DESCRIPTION
This PR implements `Board::new` for creating new game boards. 
All aspects of the board are only dependent on the side length of the square board, which must be odd and greater than two.
The tiles on the board are generated randomly each time.