### PR TITLE
Implement `Players::new`

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -85,6 +85,14 @@ impl Board {
             free_tile,
         }
     }
+
+    pub fn get_side_length(&self) -> usize {
+        self.side_length
+    }
+
+    pub fn get_number_of_items(&self) -> usize {
+        calculate_number_of_items(self.side_length)
+    }
 }
 
 fn get_tile_assortment(side_length: usize) -> Vec<TileVariant> {

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -5,10 +5,15 @@ pub mod tile;
 
 #[cfg(test)]
 mod tests {
-    use crate::board::Board;
+    use crate::{board::Board, player::Players};
 
     #[test]
     fn new_board() {
         Board::new(7);
+    }
+
+    #[test]
+    fn new_players() {
+        Players::new(vec![0, 1, 2, 3], 6, &Board::new(7));
     }
 }

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, iter};
 
 use rand::seq::SliceRandom;
 use ts_interop::ts_interop;
@@ -97,8 +97,8 @@ fn get_start_position(index: usize, side_length: usize) -> Position {
 fn get_items_to_collect(num_board_items: usize, num_item_cards: usize) -> Vec<Item> {
     let num_repeats = num_item_cards / num_board_items;
     let num_remainder = num_item_cards % num_board_items;
-    let mut items: Vec<_> = (0..num_repeats)
-        .map(|_| (1..=num_board_items))
+    let mut items: Vec<_> = iter::repeat(1..=num_board_items)
+        .take(num_repeats)
         .flatten()
         .map(Item::new)
         .collect();

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
+use rand::seq::SliceRandom;
 use ts_interop::ts_interop;
 
-use crate::tile::Item;
+use crate::{board::Board, tile::Item};
 
 #[cfg_attr(feature = "wasm", tsify::declare)]
 pub type PlayerId = usize;
@@ -30,4 +31,78 @@ pub struct Player {
 pub struct Position {
     x: usize,
     y: usize,
+}
+
+impl Players {
+    pub fn new(mut ids: Vec<PlayerId>, items_per_player: usize, board: &Board) -> Self {
+        assert!(ids.len() > 1);
+        ids.sort();
+
+        let player_turn = *ids.first().unwrap();
+        let mut items =
+            get_items_to_collect(board.get_number_of_items(), ids.len() * items_per_player);
+        items.shuffle(&mut rand::thread_rng());
+
+        let players = ids
+            .into_iter()
+            .enumerate()
+            .map(|(index, id)| {
+                (
+                    id,
+                    Player::new(
+                        id,
+                        get_start_position(index, board.get_side_length()),
+                        items.drain(0..items_per_player).collect(),
+                    ),
+                )
+            })
+            .collect();
+
+        assert!(items.is_empty());
+
+        Self {
+            players,
+            player_turn,
+        }
+    }
+}
+
+impl Player {
+    pub fn new(id: PlayerId, start_position: Position, to_collect: Vec<Item>) -> Self {
+        Self {
+            id,
+            position: start_position,
+            start_position,
+            collected: Vec::new(),
+            to_collect,
+        }
+    }
+}
+
+impl Position {
+    pub fn new(x: usize, y: usize) -> Self {
+        Self { x, y }
+    }
+}
+
+fn get_start_position(index: usize, side_length: usize) -> Position {
+    match index % 4 {
+        0 => Position::new(0, 0),
+        1 => Position::new(0, side_length - 1),
+        2 => Position::new(side_length - 1, side_length - 1),
+        _ => Position::new(side_length - 1, 0),
+    }
+}
+
+fn get_items_to_collect(num_board_items: usize, num_item_cards: usize) -> Vec<Item> {
+    let num_repeats = num_item_cards / num_board_items;
+    let num_remainder = num_item_cards % num_board_items;
+    let mut items: Vec<_> = (0..num_repeats)
+        .map(|_| (1..=num_board_items))
+        .flatten()
+        .map(Item::new)
+        .collect();
+    items.extend((1..=num_remainder).map(Item::new));
+
+    items
 }


### PR DESCRIPTION
This PR implements `Players::new` for creating new players.
Players are generated based on the given player `ids` with each having `items_per_player` item cards shuffled randomly.
The assignment of the player starting location and the type of item cards are determined by the game `board` in use.
