### PR TITLE
Implement game logic

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -1,9 +1,12 @@
-use std::iter;
+use std::{collections::HashMap, iter};
 
 use rand::seq::{IteratorRandom, SliceRandom};
 use ts_interop::ts_interop;
 
-use crate::tile::{FreeTile, Item, Rotation, Tile, TileVariant};
+use crate::{
+    player::Position,
+    tile::{FreeTile, Item, Rotation, SideIndex, Tile, TileVariant},
+};
 
 #[ts_interop]
 #[derive(Clone)]
@@ -92,6 +95,22 @@ impl Board {
 
     pub fn get_number_of_items(&self) -> usize {
         calculate_number_of_items(self.side_length)
+    }
+
+    pub fn get_item(&self, position: Position) -> Option<Item> {
+        self.get(position).get_item()
+    }
+
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
+        self.free_tile.set_rotation(rotation);
+    }
+
+    pub fn shift_tiles(&mut self, _side_index: SideIndex) -> HashMap<Position, Position> {
+        todo!()
+    }
+
+    fn get(&self, position: Position) -> &Tile {
+        &self.tiles[position.get_x() * self.side_length + position.get_y()]
     }
 }
 

--- a/game-core/game/src/game.rs
+++ b/game-core/game/src/game.rs
@@ -2,7 +2,8 @@ use ts_interop::ts_interop;
 
 use crate::{
     board::Board,
-    player::{PlayerId, Players},
+    player::{MoveResult, PlayerId, Players, Position},
+    tile::{Rotation, SideIndex},
 };
 
 #[ts_interop]
@@ -25,4 +26,71 @@ pub struct GameStartSettings {
     players: Vec<PlayerId>,
     side_length: usize,
     items_per_player: usize,
+}
+
+impl Game {
+    pub fn new(settings: GameStartSettings) -> Self {
+        let board = Board::new(settings.side_length);
+        let players = Players::new(settings.players, settings.items_per_player, &board);
+
+        Self {
+            board,
+            players,
+            phase: GamePhase::MoveTiles,
+        }
+    }
+
+    pub fn get_board(&self) -> &Board {
+        &self.board
+    }
+
+    pub fn get_players(&self) -> &Players {
+        &self.players
+    }
+
+    pub fn get_phase(&self) -> GamePhase {
+        self.phase
+    }
+
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
+        self.board.rotate_free_tile(rotation);
+    }
+
+    pub fn shift_tiles(&mut self, side_index: SideIndex) {
+        assert!(self.phase == GamePhase::MoveTiles);
+        self.board.shift_tiles(side_index);
+        self.phase = GamePhase::MovePlayer;
+    }
+
+    pub fn remove_player(&mut self, player_id: PlayerId) {
+        self.players.remove_player(player_id);
+    }
+
+    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Option<PlayerId> {
+        assert!(self.phase == GamePhase::MovePlayer);
+
+        // TODO: check validity
+        match self.players.move_player(player_id, position) {
+            MoveResult::Won(id) => return Some(id),
+            MoveResult::Moved(player) => player.try_collect_item(&self.board),
+        }
+
+        self.players.next_player_turn();
+        self.phase = GamePhase::MoveTiles;
+        None
+    }
+
+    pub fn into_parts(self) -> (Board, Players, GamePhase) {
+        (self.board, self.players, self.phase)
+    }
+}
+
+impl GameStartSettings {
+    pub fn new(players: Vec<PlayerId>, side_length: usize, items_per_player: usize) -> Self {
+        Self {
+            players,
+            side_length,
+            items_per_player,
+        }
+    }
 }

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -5,7 +5,11 @@ pub mod tile;
 
 #[cfg(test)]
 mod tests {
-    use crate::{board::Board, player::Players};
+    use crate::{
+        board::Board,
+        game::{Game, GameStartSettings},
+        player::Players,
+    };
 
     #[test]
     fn new_board() {
@@ -15,5 +19,10 @@ mod tests {
     #[test]
     fn new_players() {
         Players::new(vec![0, 1, 2, 3], 6, &Board::new(7));
+    }
+
+    #[test]
+    fn new_game() {
+        Game::new(GameStartSettings::new(vec![0, 1, 2, 3], 7, 6));
     }
 }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -79,6 +79,10 @@ impl Tile {
             item,
         }
     }
+
+    pub fn get_item(&self) -> Option<Item> {
+        self.item
+    }
 }
 
 impl Item {
@@ -95,5 +99,9 @@ impl FreeTile {
             tile,
             side_with_index: None,
         }
+    }
+
+    pub fn set_rotation(&mut self, rotation: Rotation) {
+        self.tile.rotation = rotation;
     }
 }

--- a/game-core/wasm/src/lib.rs
+++ b/game-core/wasm/src/lib.rs
@@ -33,42 +33,100 @@ pub struct GameCore {
     callbacks: GameCoreCallbacks,
 }
 
+impl GameCore {
+    fn update_board(&self, board: Board) {
+        self.callbacks.update_board(board);
+    }
+
+    fn update_players(&self, players: Players) {
+        self.callbacks.update_players(players)
+    }
+
+    fn update_phase(&self, phase: GamePhase) {
+        self.callbacks.update_phase(phase);
+    }
+
+    fn do_action(&mut self, action: impl FnOnce(&mut Game)) -> Option<Game> {
+        if let Some(mut current) = self.history.last().cloned() {
+            action(&mut current);
+            if self.history.len() < self.history.capacity() {
+                self.history.push(current);
+            } else {
+                self.history.rotate_left(1);
+                *self.history.last_mut().unwrap() = current;
+            }
+            self.history.last().cloned()
+        } else {
+            None
+        }
+    }
+}
+
 #[wasm_bindgen]
 impl GameCore {
     #[wasm_bindgen(constructor)]
     pub fn new(callbacks: GameCoreCallbacks, history_size: usize) -> Self {
-        todo!()
+        Self {
+            history: Vec::with_capacity(history_size),
+            callbacks,
+        }
     }
 
     pub fn get_current_game(&self) -> Option<Game> {
-        todo!()
+        self.history.last().cloned()
     }
 
     pub fn set_game(&mut self, game: Game) {
-        todo!()
+        self.history.clear();
+        self.history.push(game);
     }
 
     pub fn start_game(&mut self, settings: GameStartSettings) {
-        todo!()
+        let game = Game::new(settings);
+        let (board, players, phase) = game.clone().into_parts();
+        self.update_board(board);
+        self.update_players(players);
+        self.update_phase(phase);
+        self.set_game(game);
     }
 
     pub fn rotate_free_tile(&mut self, rotation: Rotation) {
-        todo!()
+        if let Some(game) = self.do_action(|game| game.rotate_free_tile(rotation)) {
+            self.update_board(game.into_parts().0);
+        }
     }
 
     pub fn shift_tiles(&mut self, side_index: SideIndex) {
-        todo!()
+        if let Some(game) = self.do_action(|game| game.shift_tiles(side_index)) {
+            let (board, players, phase) = game.into_parts();
+            self.update_board(board);
+            self.update_players(players);
+            self.update_phase(phase);
+        }
     }
 
     pub fn remove_player(&mut self, player_id: PlayerId) {
-        todo!()
+        if let Some(game) = self.do_action(|game| game.remove_player(player_id)) {
+            self.update_players(game.into_parts().1);
+        }
     }
 
-    pub fn move_player(&mut self, player_id: PlayerId, position: Position) {
-        todo!()
+    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Option<PlayerId> {
+        let mut winner = None;
+        if let Some(game) = self.do_action(|game| winner = game.move_player(player_id, position)) {
+            let (_, players, phase) = game.into_parts();
+            self.update_players(players);
+            self.update_phase(phase);
+        }
+        winner
     }
 
     pub fn undo_move(&mut self) {
-        todo!()
+        self.history.pop();
+        if let Some(game) = self.history.last() {
+            self.update_board(game.get_board().clone());
+            self.update_players(game.get_players().clone());
+            self.update_phase(game.get_phase());
+        }
     }
 }


### PR DESCRIPTION
This PR implements most of the game logic in the backend.
It also changes the API, where the game logic requires it.

Todos:
- implement `Board::shift_tiles`
- check movement validity for `Game::move_player` (optional)

Depends on: #8 