### PR TITLE
Implement `Board::shift_tiles`

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -120,13 +120,20 @@ fn get_tile_assortment(side_length: usize) -> Vec<TileVariant> {
     const L_RATIO: f64 = 15. / 34.;
 
     let num_moveable = side_length.pow(2) - (side_length / 2 + 1).pow(2) + 1;
-    let num_t_tiles = (num_moveable as f64 * T_RATIO) as usize; // flooring
-    let num_i_tiles = (num_moveable as f64 * I_RATIO) as usize;
+    let num_i_tiles = (num_moveable as f64 * I_RATIO) as usize; // flooring
+    let mut num_t_tiles = (num_moveable as f64 * T_RATIO) as usize;
     let mut num_l_tiles = (num_moveable as f64 * L_RATIO) as usize;
 
-    if num_t_tiles + num_i_tiles + num_l_tiles != num_moveable {
-        num_l_tiles += 1;
+    match num_moveable - (num_t_tiles + num_i_tiles + num_l_tiles) {
+        diff @ (1 | 2) => {
+            num_l_tiles += 1;
+            if diff == 2 {
+                num_t_tiles += 1;
+            }
+        }
+        _ => {}
     }
+
     assert!(num_t_tiles + num_i_tiles + num_l_tiles == num_moveable);
 
     let mut movable_tiles = Vec::with_capacity(num_moveable);

--- a/game-core/game/src/game.rs
+++ b/game-core/game/src/game.rs
@@ -58,7 +58,12 @@ impl Game {
 
     pub fn shift_tiles(&mut self, side_index: SideIndex) {
         assert!(self.phase == GamePhase::MoveTiles);
-        self.board.shift_tiles(side_index);
+        let changes = self.board.shift_tiles(side_index);
+        for player in self.players.iter_mut() {
+            if let Some(new_pos) = changes.get(&player.get_position()) {
+                player.set_position(*new_pos);
+            }
+        }
         self.phase = GamePhase::MovePlayer;
     }
 

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -17,6 +17,13 @@ mod tests {
     }
 
     #[test]
+    fn big_boards() {
+        for i in 4..30 {
+            Board::new(2 * i + 1);
+        }
+    }
+
+    #[test]
     fn new_players() {
         Players::new(vec![0, 1, 2, 3], 6, &Board::new(7));
     }

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(get_many_mut)]
+
 pub mod board;
 pub mod game;
 pub mod player;

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -27,7 +27,7 @@ pub struct Player {
 }
 
 #[ts_interop]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Position {
     x: usize,
     y: usize,
@@ -69,6 +69,10 @@ impl Players {
             players,
             player_turn,
         }
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Player> {
+        self.players.values_mut()
     }
 
     pub fn remove_player(&mut self, player_id: PlayerId) {
@@ -115,6 +119,10 @@ impl Player {
         }
     }
 
+    pub fn get_position(&self) -> Position {
+        self.position
+    }
+
     pub fn get_next_to_collect(&self) -> Option<Item> {
         self.to_collect.last().copied()
     }
@@ -124,6 +132,7 @@ impl Player {
     }
 
     pub fn set_position(&mut self, position: Position) {
+        assert!(position != self.position);
         self.position = position;
     }
 

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -62,7 +62,7 @@ pub struct SideIndex {
 
 /// The side of the board where the free tile is located.
 #[ts_interop]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Side {
     Top,
     Right,
@@ -103,5 +103,19 @@ impl FreeTile {
 
     pub fn set_rotation(&mut self, rotation: Rotation) {
         self.tile.rotation = rotation;
+    }
+
+    pub fn tile_mut(&mut self) -> &mut Tile {
+        &mut self.tile
+    }
+}
+
+impl SideIndex {
+    pub fn get_side(&self) -> Side {
+        self.side
+    }
+
+    pub fn get_index(&self) -> usize {
+        self.index
     }
 }


### PR DESCRIPTION
This PR implements `Board::shift_tiles`, thereby completing the functionality of the backend.

Optional Todos: replace `assert!`s with `Result` as return values.

Depends on: #11 