### PR TITLE
Improve `shift_tiles`

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -142,8 +142,7 @@ impl Board {
                 for i in range.into_iter() {
                     let current = start + i * self.side_length;
                     let next = current + self.side_length;
-                    let [current, next] = self.tiles.get_many_mut([current, next]).unwrap();
-                    mem::swap(current, next);
+                    self.tiles.swap(current, next);
                     insert(i);
                 }
 

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(get_many_mut)]
-
 pub mod board;
 pub mod game;
 pub mod player;


### PR DESCRIPTION
This PR improves `Board::shift_tiles` by simplifying the swaps and no longer requiring nightly features.