### PR TITLE
Implement setting `side_index` for `FreeTile`

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -177,6 +177,7 @@ impl Board {
         };
 
         mem::swap(&mut self.tiles[last], self.free_tile.tile_mut());
+        self.free_tile.set_side_index(side_index.shift());
 
         map
     }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -108,6 +108,10 @@ impl FreeTile {
     pub fn tile_mut(&mut self) -> &mut Tile {
         &mut self.tile
     }
+
+    pub fn set_side_index(&mut self, side_index: SideIndex) {
+        self.side_with_index = Some(side_index);
+    }
 }
 
 impl SideIndex {
@@ -117,5 +121,19 @@ impl SideIndex {
 
     pub fn get_index(&self) -> usize {
         self.index
+    }
+
+    pub fn shift(&self) -> Self {
+        let side = match self.side {
+            Side::Top => Side::Bottom,
+            Side::Right => Side::Left,
+            Side::Bottom => Side::Top,
+            Side::Left => Side::Right,
+        };
+
+        Self {
+            side,
+            index: self.index,
+        }
     }
 }


### PR DESCRIPTION
This PR updates `Board::shift_tiles` by implementing setting `side_with_index` of the `FreeTile` after the shift.