### PR TITLE
Make game reactive

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -177,6 +177,7 @@ impl Board {
         };
 
         mem::swap(&mut self.tiles[last], self.free_tile.tile_mut());
+        self.free_tile.set_side_index(side_index.shift());
 
         map
     }

--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, iter, mem};
+use std::{collections::HashMap, iter, mem, ops::Index};
 
 use rand::seq::{IteratorRandom, SliceRandom};
 use ts_interop::ts_interop;
@@ -16,11 +16,33 @@ pub struct Board {
     free_tile: FreeTile,
 }
 
+pub type PositionMap = HashMap<Position, Position>;
+
+#[derive(Debug)]
+pub enum NewBoardError {
+    TooSmall,
+    EvenLength,
+}
+
+#[derive(Debug)]
+pub enum ShiftTileError {
+    OutOfBounds,
+    UnMovable,
+    UndoMove,
+}
+
 impl Board {
-    pub fn new(side_length: usize) -> Self {
-        assert!(side_length % 2 == 1 && side_length > 2);
+    pub fn new(side_length: usize) -> Result<Self, NewBoardError> {
         use Rotation::*;
         use TileVariant::*;
+
+        if side_length < 3 {
+            return Err(NewBoardError::TooSmall);
+        }
+
+        if side_length % 2 == 0 {
+            return Err(NewBoardError::EvenLength);
+        }
 
         let rotations = [Ninety, TwoSeventy, Zero, OneEighty];
 
@@ -82,11 +104,11 @@ impl Board {
         };
         let free_tile = FreeTile::new(Tile::new(side_length.pow(2), free_tile, Zero, item));
 
-        Self {
+        Ok(Self {
             tiles,
             side_length,
             free_tile,
-        }
+        })
     }
 
     pub fn get_side_length(&self) -> usize {
@@ -97,26 +119,41 @@ impl Board {
         calculate_number_of_items(self.side_length)
     }
 
-    pub fn get_item(&self, position: Position) -> Option<Item> {
-        self.get(position).get_item()
+    pub fn get_tile(&self, position: Position) -> Option<&Tile> {
+        let x = position.get_x();
+        let y = position.get_y();
+        if x >= self.side_length || y >= self.side_length {
+            return None;
+        }
+        self.tiles.get(x * self.side_length + y)
     }
 
-    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) -> FreeTile {
         self.free_tile.set_rotation(rotation);
+        self.free_tile
     }
 
-    pub fn shift_tiles(&mut self, side_index: SideIndex) -> HashMap<Position, Position> {
-        assert!(side_index.get_index() % 2 == 1);
-        assert!(side_index.get_index() < self.side_length);
+    pub fn shift_tiles(&mut self, side_index: SideIndex) -> Result<PositionMap, ShiftTileError> {
         use Side::*;
+        let index = side_index.get_index();
+
+        if index >= self.side_length {
+            return Err(ShiftTileError::OutOfBounds);
+        }
+
+        if index % 2 == 0 {
+            return Err(ShiftTileError::UnMovable);
+        }
+
+        if self.free_tile.get_side_index() == Some(side_index) {
+            return Err(ShiftTileError::UndoMove);
+        }
 
         let to_next = |r: usize| (r + 1) % self.side_length;
         let to_last = |r: usize| r.checked_sub(1).unwrap_or(self.side_length - 1);
 
         let (last, map) = match side_index.get_side() {
             side @ (Top | Bottom) => {
-                let start = side_index.get_index();
-
                 let mut range = 0..self.side_length - 1;
                 let mut rev = range.clone().rev();
 
@@ -125,22 +162,18 @@ impl Board {
                         (
                             &mut range,
                             &to_last,
-                            start + self.tiles.len() - self.side_length,
+                            index + self.tiles.len() - self.side_length,
                         )
                     } else {
-                        (&mut rev, &to_next, start)
+                        (&mut rev, &to_next, index)
                     };
 
                 let mut map = HashMap::new();
-                let mut insert = |col| {
-                    map.insert(
-                        Position::new(side_index.get_index(), col),
-                        Position::new(side_index.get_index(), to_fn(col)),
-                    )
-                };
+                let mut insert =
+                    |col| map.insert(Position::new(index, col), Position::new(index, to_fn(col)));
 
                 for i in range.into_iter() {
-                    let current = start + i * self.side_length;
+                    let current = index + i * self.side_length;
                     let next = current + self.side_length;
                     self.tiles.swap(current, next);
                     insert(i);
@@ -150,7 +183,7 @@ impl Board {
                 (last, map)
             }
             side @ (Right | Left) => {
-                let start = side_index.get_index() * self.side_length;
+                let start = index * self.side_length;
                 let end = start + self.side_length - 1;
                 let row = &mut self.tiles[start..=end];
 
@@ -165,12 +198,7 @@ impl Board {
                 (
                     last,
                     (0..self.side_length)
-                        .map(|row| {
-                            (
-                                Position::new(row, side_index.get_index()),
-                                Position::new(to_fn(row), side_index.get_index()),
-                            )
-                        })
+                        .map(|row| (Position::new(row, index), Position::new(to_fn(row), index)))
                         .collect(),
                 )
             }
@@ -179,11 +207,15 @@ impl Board {
         mem::swap(&mut self.tiles[last], self.free_tile.tile_mut());
         self.free_tile.set_side_index(side_index.shift());
 
-        map
+        Ok(map)
     }
+}
 
-    fn get(&self, position: Position) -> &Tile {
-        &self.tiles[position.get_x() * self.side_length + position.get_y()]
+impl Index<Position> for Board {
+    type Output = Tile;
+
+    fn index(&self, index: Position) -> &Self::Output {
+        self.get_tile(index).unwrap()
     }
 }
 

--- a/game-core/game/src/game.rs
+++ b/game-core/game/src/game.rs
@@ -1,9 +1,9 @@
 use ts_interop::ts_interop;
 
 use crate::{
-    board::Board,
+    board::{Board, NewBoardError, ShiftTileError},
     player::{MoveResult, PlayerId, Players, Position},
-    tile::{Rotation, SideIndex},
+    tile::{FreeTile, Rotation, SideIndex},
 };
 
 #[ts_interop]
@@ -28,20 +28,33 @@ pub struct GameStartSettings {
     items_per_player: usize,
 }
 
-impl Game {
-    pub fn new(settings: GameStartSettings) -> Self {
-        let board = Board::new(settings.side_length);
-        let players = Players::new(settings.players, settings.items_per_player, &board);
+#[derive(Debug)]
+pub enum NewGameError {
+    BoardError(NewBoardError),
+    PlayerError,
+}
 
-        Self {
+pub enum GameError<T> {
+    StateError,
+    ActionError(T),
+}
+
+pub enum MovePlayerError {
+    InvalidPosition,
+    InvalidPlayer,
+}
+
+impl Game {
+    pub fn new(settings: GameStartSettings) -> Result<Self, NewGameError> {
+        let board = Board::new(settings.side_length)?;
+        let players = Players::new(settings.players, settings.items_per_player, &board)
+            .ok_or(NewGameError::PlayerError)?;
+
+        Ok(Self {
             board,
             players,
             phase: GamePhase::MoveTiles,
-        }
-    }
-
-    pub fn get_board(&self) -> &Board {
-        &self.board
+        })
     }
 
     pub fn get_players(&self) -> &Players {
@@ -52,41 +65,53 @@ impl Game {
         self.phase
     }
 
-    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
-        self.board.rotate_free_tile(rotation);
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) -> FreeTile {
+        self.board.rotate_free_tile(rotation)
     }
 
-    pub fn shift_tiles(&mut self, side_index: SideIndex) {
-        assert!(self.phase == GamePhase::MoveTiles);
-        let changes = self.board.shift_tiles(side_index);
+    pub fn shift_tiles(&mut self, side_index: SideIndex) -> Result<(), GameError<ShiftTileError>> {
+        if self.phase != GamePhase::MoveTiles {
+            return Err(GameError::StateError);
+        }
+
+        let changes = self.board.shift_tiles(side_index)?;
         for player in self.players.iter_mut() {
             if let Some(new_pos) = changes.get(&player.get_position()) {
                 player.set_position(*new_pos);
             }
         }
         self.phase = GamePhase::MovePlayer;
+
+        Ok(())
     }
 
-    pub fn remove_player(&mut self, player_id: PlayerId) {
-        self.players.remove_player(player_id);
+    pub fn remove_player(&mut self, player_id: PlayerId) -> Result<Option<PlayerId>, ()> {
+        self.players.remove_player(player_id)
     }
 
-    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Option<PlayerId> {
-        assert!(self.phase == GamePhase::MovePlayer);
+    pub fn move_player(
+        &mut self,
+        player_id: PlayerId,
+        position: Position,
+    ) -> Result<Option<PlayerId>, GameError<MovePlayerError>> {
+        if self.phase != GamePhase::MovePlayer {
+            return Err(GameError::StateError);
+        }
+
+        if self.board.get_tile(position).is_none() {
+            return Err(MovePlayerError::InvalidPosition.into());
+        }
 
         // TODO: check validity
         match self.players.move_player(player_id, position) {
-            MoveResult::Won(id) => return Some(id),
             MoveResult::Moved(player) => player.try_collect_item(&self.board),
+            MoveResult::Won(id) => return Ok(Some(id)),
+            MoveResult::InvalidPlayer => return Err(MovePlayerError::InvalidPlayer.into()),
         }
 
         self.players.next_player_turn();
         self.phase = GamePhase::MoveTiles;
-        None
-    }
-
-    pub fn into_parts(self) -> (Board, Players, GamePhase) {
-        (self.board, self.players, self.phase)
+        Ok(None)
     }
 }
 
@@ -97,5 +122,17 @@ impl GameStartSettings {
             side_length,
             items_per_player,
         }
+    }
+}
+
+impl From<NewBoardError> for NewGameError {
+    fn from(value: NewBoardError) -> Self {
+        NewGameError::BoardError(value)
+    }
+}
+
+impl<E> From<E> for GameError<E> {
+    fn from(value: E) -> Self {
+        GameError::ActionError(value)
     }
 }

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -6,30 +6,73 @@ pub mod tile;
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
-        game::{Game, GameStartSettings},
-        player::Players,
+        board::{Board, NewBoardError},
+        game::{Game, GameStartSettings, NewGameError},
+        player::{MoveResult, Players, Position},
+        tile::{Side, SideIndex},
     };
 
+    fn new_board() -> Result<Board, NewBoardError> {
+        Board::new(7)
+    }
+
+    fn new_players() -> Option<Players> {
+        Players::new(vec![0, 1, 2, 3], 6, &new_board().unwrap())
+    }
+
+    fn new_game() -> Result<Game, NewGameError> {
+        Game::new(GameStartSettings::new(vec![0, 1, 2, 3], 7, 6))
+    }
+
     #[test]
-    fn new_board() {
-        Board::new(7);
+    fn new_board_ok() {
+        assert!(new_board().is_ok());
+    }
+
+    #[test]
+    fn shift_tiles() {
+        assert!(new_board()
+            .unwrap()
+            .shift_tiles(SideIndex::new(Side::Top, 1))
+            .is_ok());
     }
 
     #[test]
     fn big_boards() {
         for i in 4..30 {
-            Board::new(2 * i + 1);
+            assert!(Board::new(2 * i + 1).is_ok());
         }
     }
 
     #[test]
-    fn new_players() {
-        Players::new(vec![0, 1, 2, 3], 6, &Board::new(7));
+    fn new_players_ok() {
+        assert!(new_players().is_some());
     }
 
     #[test]
-    fn new_game() {
-        Game::new(GameStartSettings::new(vec![0, 1, 2, 3], 7, 6));
+    fn remove_player() {
+        assert!(new_players().unwrap().remove_player(0).is_ok());
+    }
+
+    #[test]
+    fn move_player() {
+        let new_pos = Position::new(0, 0);
+        match new_players().unwrap().move_player(0, new_pos) {
+            MoveResult::Moved(player) => assert!(player.get_position() == new_pos),
+            _ => panic!("Wrong result"),
+        };
+    }
+
+    #[test]
+    fn new_game_ok() {
+        assert!(new_game().is_ok());
+    }
+
+    #[test]
+    fn game_actions() {
+        let mut game = new_game().unwrap();
+        assert!(game.shift_tiles(SideIndex::new(Side::Top, 1)).is_ok());
+        assert!(game.remove_player(0).is_ok());
+        assert!(game.move_player(1, Position::new(0, 6)).is_ok());
     }
 }

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -34,13 +34,17 @@ pub struct Position {
 }
 
 pub enum MoveResult<'a> {
-    Won(PlayerId),
     Moved(&'a mut Player),
+    Won(PlayerId),
+    InvalidPlayer,
 }
 
 impl Players {
-    pub fn new(mut ids: Vec<PlayerId>, items_per_player: usize, board: &Board) -> Self {
-        assert!(ids.len() > 1);
+    pub fn new(mut ids: Vec<PlayerId>, items_per_player: usize, board: &Board) -> Option<Self> {
+        if ids.len() < 2 {
+            return None;
+        }
+
         ids.sort();
 
         let player_turn = *ids.first().unwrap();
@@ -65,21 +69,30 @@ impl Players {
 
         assert!(items.is_empty());
 
-        Self {
+        Some(Self {
             players,
             player_turn,
-        }
+        })
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Player> {
         self.players.values_mut()
     }
 
-    pub fn remove_player(&mut self, player_id: PlayerId) {
-        self.players.remove(&player_id);
+    pub fn remove_player(&mut self, player_id: PlayerId) -> Result<Option<PlayerId>, ()> {
+        if self.players.remove(&player_id).is_none() {
+            return Err(());
+        }
+
+        if self.players.len() == 1 {
+            return Ok(self.players.first_key_value().map(|(id, _)| *id));
+        }
+
         if player_id == self.player_turn {
             self.next_player_turn();
         }
+
+        Ok(None)
     }
 
     pub fn next_player_turn(&mut self) {
@@ -87,24 +100,23 @@ impl Players {
             .players
             .range(self.player_turn..)
             .next()
-            .or_else(|| self.players.iter().next())
+            .or_else(|| self.players.first_key_value())
             .map(|(id, _)| *id)
-            .unwrap_or_default();
+            .unwrap();
     }
 
     pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> MoveResult {
-        let player = self.get_mut(player_id);
-        player.set_position(position);
+        if let Some(player) = self.players.get_mut(&player_id) {
+            player.set_position(position);
 
-        if player.get_next_to_collect().is_none() && player.is_at_start() {
-            MoveResult::Won(player_id)
+            if player.get_next_to_collect().is_none() && player.is_at_start() {
+                MoveResult::Won(player_id)
+            } else {
+                MoveResult::Moved(player)
+            }
         } else {
-            MoveResult::Moved(player)
+            MoveResult::InvalidPlayer
         }
-    }
-
-    fn get_mut(&mut self, player_id: PlayerId) -> &mut Player {
-        self.players.get_mut(&player_id).unwrap()
     }
 }
 
@@ -132,13 +144,12 @@ impl Player {
     }
 
     pub fn set_position(&mut self, position: Position) {
-        assert!(position != self.position);
         self.position = position;
     }
 
     pub fn try_collect_item(&mut self, board: &Board) {
         let next = self.get_next_to_collect();
-        if next.is_some() && next == board.get_item(self.position) {
+        if next.is_some() && next == board[self.position].get_item() {
             self.collected.push(self.to_collect.pop().unwrap());
         }
     }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -108,6 +108,10 @@ impl FreeTile {
     pub fn tile_mut(&mut self) -> &mut Tile {
         &mut self.tile
     }
+
+    pub fn set_side_index(&mut self, side_index: SideIndex) {
+        self.side_with_index = Some(side_index);
+    }
 }
 
 impl SideIndex {
@@ -117,5 +121,19 @@ impl SideIndex {
 
     pub fn get_index(&self) -> usize {
         self.index
+    }
+
+    pub fn shift(&self) -> Self {
+        let side = match self.side {
+            Side::Top => Side::Bottom,
+            Side::Right => Side::Left,
+            Side::Bottom => Side::Top,
+            Side::Left => Side::Right,
+        };
+
+        Self {
+            side,
+            index: self.index,
+        }
     }
 }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -54,7 +54,7 @@ pub struct FreeTile {
 
 /// The index always goes from left to right or from top to bottom.
 #[ts_interop]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SideIndex {
     side: Side,
     index: usize,
@@ -101,6 +101,10 @@ impl FreeTile {
         }
     }
 
+    pub fn get_side_index(&self) -> Option<SideIndex> {
+        self.side_with_index
+    }
+
     pub fn set_rotation(&mut self, rotation: Rotation) {
         self.tile.rotation = rotation;
     }
@@ -115,6 +119,10 @@ impl FreeTile {
 }
 
 impl SideIndex {
+    pub fn new(side: Side, index: usize) -> Self {
+        Self { side, index }
+    }
+
     pub fn get_side(&self) -> Side {
         self.side
     }

--- a/game-core/wasm/src/lib.rs
+++ b/game-core/wasm/src/lib.rs
@@ -1,26 +1,25 @@
 use std::collections::VecDeque;
 
 use game::{
-    board::Board,
-    game::{Game, GamePhase, GameStartSettings},
-    player::{PlayerId, Players, Position},
+    board::{NewBoardError, ShiftTileError},
+    game::{Game, GameError, GameStartSettings, MovePlayerError, NewGameError},
+    player::{PlayerId, Position},
     tile::{Rotation, SideIndex},
 };
 use log::Level;
-use wasm_bindgen::prelude::wasm_bindgen;
+use serde::Serialize;
+use serde_wasm_bindgen::Serializer;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 #[wasm_bindgen]
 extern "C" {
-    pub type GameCoreCallbacks;
+    pub type Observer;
 
     #[wasm_bindgen(method)]
-    fn update_board(this: &GameCoreCallbacks, board: Board);
+    fn next(this: &Observer, value: JsValue);
 
     #[wasm_bindgen(method)]
-    fn update_players(this: &GameCoreCallbacks, players: Players);
-
-    #[wasm_bindgen(method)]
-    fn update_phase(this: &GameCoreCallbacks, phase: GamePhase);
+    fn error(this: &Observer, value: JsValue);
 }
 
 #[wasm_bindgen(start)]
@@ -30,36 +29,52 @@ fn main() {
 }
 
 #[wasm_bindgen]
+pub struct Observable {
+    result: Result<JsValue, JsValue>,
+}
+
+#[wasm_bindgen]
 pub struct GameCore {
     history: VecDeque<Game>,
-    callbacks: GameCoreCallbacks,
+    serializer: Serializer,
+}
+
+impl From<Result<JsValue, JsValue>> for Observable {
+    fn from(result: Result<JsValue, JsValue>) -> Self {
+        Self { result }
+    }
+}
+
+#[wasm_bindgen]
+impl Observable {
+    pub fn subscribe(self, observer: Observer) {
+        match self.result {
+            Ok(value) => observer.next(value),
+            Err(err) => observer.error(err),
+        };
+    }
 }
 
 impl GameCore {
-    fn update_board(&self, board: Board) {
-        self.callbacks.update_board(board);
+    fn serialize<T: Serialize>(&self, value: T) -> Result<JsValue, JsValue> {
+        value.serialize(&self.serializer).map_err(Into::into)
     }
 
-    fn update_players(&self, players: Players) {
-        self.callbacks.update_players(players)
-    }
-
-    fn update_phase(&self, phase: GamePhase) {
-        self.callbacks.update_phase(phase);
-    }
-
-    fn do_action(&mut self, action: impl FnOnce(&mut Game)) -> Option<Game> {
+    fn do_action<T: Serialize>(
+        &mut self,
+        action: impl FnOnce(&mut Game) -> Result<T, JsValue>,
+    ) -> Result<JsValue, JsValue> {
         if let Some(mut current) = self.history.back().cloned() {
-            action(&mut current);
+            let result = action(&mut current)?;
             if self.history.len() < self.history.capacity() {
                 self.history.push_back(current);
             } else {
                 self.history.rotate_left(1);
                 *self.history.back_mut().unwrap() = current;
             }
-            self.history.back().cloned()
+            self.serialize(result)
         } else {
-            None
+            Err("Cannot complete action: Game not started".into())
         }
     }
 }
@@ -67,15 +82,21 @@ impl GameCore {
 #[wasm_bindgen]
 impl GameCore {
     #[wasm_bindgen(constructor)]
-    pub fn new(callbacks: GameCoreCallbacks, history_size: usize) -> Self {
+    pub fn new(history_size: usize) -> Self {
         Self {
             history: VecDeque::with_capacity(history_size),
-            callbacks,
+            serializer: Serializer::new(),
         }
     }
 
-    pub fn get_current_game(&self) -> Option<Game> {
-        self.history.back().cloned()
+    pub fn get_current_game(&self) -> Observable {
+        self.history
+            .back()
+            .map_or_else(
+                || Err("Cannot get game: Game not started".into()),
+                |game| self.serialize(game),
+            )
+            .into()
     }
 
     pub fn set_game(&mut self, game: Game) {
@@ -83,52 +104,91 @@ impl GameCore {
         self.history.push_back(game);
     }
 
-    pub fn start_game(&mut self, settings: GameStartSettings) {
-        let game = Game::new(settings);
-        let (board, players, phase) = game.clone().into_parts();
-        self.update_board(board);
-        self.update_players(players);
-        self.update_phase(phase);
-        self.set_game(game);
+    pub fn start_game(&mut self, settings: GameStartSettings) -> Observable {
+        match Game::new(settings) {
+            Ok(game) => {
+                self.set_game(game.clone());
+                self.serialize(game)
+            }
+            Err(NewGameError::PlayerError) => Err("Cannot start game: Not enough players".into()),
+            Err(NewGameError::BoardError(NewBoardError::TooSmall)) => {
+                Err("Cannot start game: Side length too small".into())
+            }
+            Err(NewGameError::BoardError(NewBoardError::EvenLength)) => {
+                Err("Cannot start game: Invalid to side length".into())
+            }
+        }
+        .into()
     }
 
-    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
-        if let Some(game) = self.do_action(|game| game.rotate_free_tile(rotation)) {
-            self.update_board(game.into_parts().0);
-        }
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) -> Observable {
+        self.do_action(|game| Ok(game.rotate_free_tile(rotation)))
+            .into()
     }
 
-    pub fn shift_tiles(&mut self, side_index: SideIndex) {
-        if let Some(game) = self.do_action(|game| game.shift_tiles(side_index)) {
-            let (board, players, phase) = game.into_parts();
-            self.update_board(board);
-            self.update_players(players);
-            self.update_phase(phase);
-        }
+    pub fn shift_tiles(&mut self, side_index: SideIndex) -> Observable {
+        self.do_action(|game| {
+            game.shift_tiles(side_index)
+                .map_err(|err| {
+                    match err {
+                        GameError::StateError => {
+                            "Cannot shift tiles: Player has to end turn by moving figure"
+                        }
+                        GameError::ActionError(ShiftTileError::OutOfBounds) => {
+                            "Cannot shift tiles: No such row/column exists"
+                        }
+                        GameError::ActionError(ShiftTileError::UnMovable) => {
+                            "Cannot shift tiles: Specified row/column is not movable"
+                        }
+                        GameError::ActionError(ShiftTileError::UndoMove) => {
+                            "Cannot shift tiles: Tile cannot be pushed back in where it was previously pushed out"
+                        }
+                    }
+                    .into()
+                })
+                .map(|_| game.clone())
+        })
+        .into()
     }
 
-    pub fn remove_player(&mut self, player_id: PlayerId) {
-        if let Some(game) = self.do_action(|game| game.remove_player(player_id)) {
-            self.update_players(game.into_parts().1);
-        }
+    pub fn remove_player(&mut self, player_id: PlayerId) -> Observable {
+        self.do_action(|game| {
+            game.remove_player(player_id)
+                .map_err(|_| "Cannot remove player: No such player exists".into())
+                .map(|winner| (game.get_players().clone(), winner))
+        })
+        .into()
     }
 
-    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Option<PlayerId> {
-        let mut winner = None;
-        if let Some(game) = self.do_action(|game| winner = game.move_player(player_id, position)) {
-            let (_, players, phase) = game.into_parts();
-            self.update_players(players);
-            self.update_phase(phase);
-        }
-        winner
+    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Observable {
+        self.do_action(|game| {
+            game.move_player(player_id, position)
+                .map_err(|err| {
+                    match err {
+                        GameError::StateError => {
+                            "Cannot move player: Player has to shift tiles first"
+                        }
+                        GameError::ActionError(MovePlayerError::InvalidPosition) => {
+                            "Cannot move player: Position is not on the board"
+                        }
+                        GameError::ActionError(MovePlayerError::InvalidPlayer) => {
+                            "Cannot move player: No such player exists"
+                        }
+                    }
+                    .into()
+                })
+                .map(|winner| (game.get_players().clone(), game.get_phase(), winner))
+        })
+        .into()
     }
 
-    pub fn undo_move(&mut self) {
-        self.history.pop_back();
-        if let Some(game) = self.history.back() {
-            self.update_board(game.get_board().clone());
-            self.update_players(game.get_players().clone());
-            self.update_phase(game.get_phase());
+    pub fn undo_move(&mut self) -> Observable {
+        if self.history.len() > 1 {
+            self.history.pop_back();
+            self.serialize(self.history.back().unwrap().clone())
+        } else {
+            Err("Cannot undo move: Last state in history".into())
         }
+        .into()
     }
 }


### PR DESCRIPTION
This PR refactors `game-core` by making it reactive.
It removes `GameCoreCallbacks` replacing the with a design is inspired by `rxjs`, where each mutating function returns an `Observable` to which the caller can subscribe an deal with the changes in the frontend.
Sadly `wasm-bindgen` currently does not support generics, so `tsify` cannot generate helpful type annotations.

The PR also adds test for the `game` crate, testing the functionality of its various components.

Depends on: #16 