### PR TITLE
Implement error handling in the backend

### DIFF
--- a/game-core/game/src/game.rs
+++ b/game-core/game/src/game.rs
@@ -1,7 +1,7 @@
 use ts_interop::ts_interop;
 
 use crate::{
-    board::Board,
+    board::{Board, NewBoardError, ShiftTileError},
     player::{MoveResult, PlayerId, Players, Position},
     tile::{Rotation, SideIndex},
 };
@@ -29,72 +29,107 @@ pub struct GameStartSettings {
     items_per_player: usize,
 }
 
-impl Game {
-    pub fn new(settings: GameStartSettings) -> Self {
-        let board = Board::new(settings.side_length);
-        let players = Players::new(settings.players, settings.items_per_player, &board);
+#[derive(Debug)]
+pub enum NewGameError {
+    BoardError(NewBoardError),
+    PlayerError,
+}
 
-        Self {
+pub type ActionResult<E> = Result<(), GameError<E>>;
+
+pub enum GameError<T> {
+    GameOver,
+    StateError,
+    ActionError(T),
+}
+
+pub enum MovePlayerError {
+    InvalidPosition,
+    InvalidPlayer,
+}
+
+impl Game {
+    pub fn new(settings: GameStartSettings) -> Result<Self, NewGameError> {
+        let board = Board::new(settings.side_length)?;
+        let players = Players::new(settings.players, settings.items_per_player, &board)
+            .ok_or(NewGameError::PlayerError)?;
+
+        Ok(Self {
             board,
             players,
             phase: GamePhase::MoveTiles,
             winner: None,
+        })
+    }
+
+    pub fn rotate_free_tile(&mut self, rotation: Rotation) -> bool {
+        if self.winner.is_some() {
+            false
+        } else {
+            self.board.rotate_free_tile(rotation);
+            true
         }
     }
 
-    pub fn get_board(&self) -> &Board {
-        &self.board
-    }
+    pub fn shift_tiles(&mut self, side_index: SideIndex) -> ActionResult<ShiftTileError> {
+        if self.winner.is_some() {
+            return Err(GameError::GameOver);
+        }
 
-    pub fn get_players(&self) -> &Players {
-        &self.players
-    }
+        if self.phase != GamePhase::MoveTiles {
+            return Err(GameError::StateError);
+        }
 
-    pub fn get_phase(&self) -> GamePhase {
-        self.phase
-    }
-
-    pub fn rotate_free_tile(&mut self, rotation: Rotation) {
-        assert!(self.winner.is_none());
-        self.board.rotate_free_tile(rotation);
-    }
-
-    pub fn shift_tiles(&mut self, side_index: SideIndex) {
-        assert!(self.winner.is_none());
-        assert!(self.phase == GamePhase::MoveTiles);
-        let changes = self.board.shift_tiles(side_index);
+        let changes = self.board.shift_tiles(side_index)?;
         for player in self.players.iter_mut() {
             if let Some(new_pos) = changes.get(&player.get_position()) {
                 player.set_position(*new_pos);
             }
         }
         self.phase = GamePhase::MovePlayer;
+
+        Ok(())
     }
 
-    pub fn remove_player(&mut self, player_id: PlayerId) {
-        assert!(self.winner.is_none());
-        self.players.remove_player(player_id);
+    pub fn remove_player(&mut self, player_id: PlayerId) -> ActionResult<()> {
+        if self.winner.is_some() {
+            return Err(GameError::GameOver);
+        }
+
+        self.winner = self.players.remove_player(player_id)?;
+
+        Ok(())
     }
 
-    pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> Option<PlayerId> {
-        assert!(self.winner.is_none());
-        assert!(self.phase == GamePhase::MovePlayer);
+    pub fn move_player(
+        &mut self,
+        player_id: PlayerId,
+        position: Position,
+    ) -> ActionResult<MovePlayerError> {
+        if self.winner.is_some() {
+            return Err(GameError::GameOver);
+        }
+
+        if self.phase != GamePhase::MovePlayer {
+            return Err(GameError::StateError);
+        }
+
+        if self.board.get_tile(position).is_none() {
+            return Err(MovePlayerError::InvalidPosition.into());
+        }
 
         // TODO: check validity
         match self.players.move_player(player_id, position) {
-            MoveResult::Won(id) => self.winner = Some(id),
             MoveResult::Moved(player) => {
                 player.try_collect_item(&self.board);
                 self.players.next_player_turn();
             }
+            MoveResult::Won(id) => self.winner = Some(id),
+            MoveResult::InvalidPlayer => return Err(MovePlayerError::InvalidPlayer.into()),
         }
 
         self.phase = GamePhase::MoveTiles;
-        self.winner
-    }
-
-    pub fn into_parts(self) -> (Board, Players, GamePhase) {
-        (self.board, self.players, self.phase)
+        Ok(())
     }
 }
 
@@ -105,5 +140,17 @@ impl GameStartSettings {
             side_length,
             items_per_player,
         }
+    }
+}
+
+impl From<NewBoardError> for NewGameError {
+    fn from(value: NewBoardError) -> Self {
+        NewGameError::BoardError(value)
+    }
+}
+
+impl<E> From<E> for GameError<E> {
+    fn from(value: E) -> Self {
+        GameError::ActionError(value)
     }
 }

--- a/game-core/game/src/lib.rs
+++ b/game-core/game/src/lib.rs
@@ -6,30 +6,73 @@ pub mod tile;
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
-        game::{Game, GameStartSettings},
-        player::Players,
+        board::{Board, NewBoardError},
+        game::{Game, GameStartSettings, NewGameError},
+        player::{MoveResult, Players, Position},
+        tile::{Side, SideIndex},
     };
 
+    fn new_board() -> Result<Board, NewBoardError> {
+        Board::new(7)
+    }
+
+    fn new_players() -> Option<Players> {
+        Players::new(vec![0, 1, 2, 3], 6, &new_board().unwrap())
+    }
+
+    fn new_game() -> Result<Game, NewGameError> {
+        Game::new(GameStartSettings::new(vec![0, 1, 2, 3], 7, 6))
+    }
+
     #[test]
-    fn new_board() {
-        Board::new(7);
+    fn new_board_ok() {
+        assert!(new_board().is_ok());
+    }
+
+    #[test]
+    fn shift_tiles() {
+        assert!(new_board()
+            .unwrap()
+            .shift_tiles(SideIndex::new(Side::Top, 1))
+            .is_ok());
     }
 
     #[test]
     fn big_boards() {
         for i in 4..30 {
-            Board::new(2 * i + 1);
+            assert!(Board::new(2 * i + 1).is_ok());
         }
     }
 
     #[test]
-    fn new_players() {
-        Players::new(vec![0, 1, 2, 3], 6, &Board::new(7));
+    fn new_players_ok() {
+        assert!(new_players().is_some());
     }
 
     #[test]
-    fn new_game() {
-        Game::new(GameStartSettings::new(vec![0, 1, 2, 3], 7, 6));
+    fn remove_player() {
+        assert!(new_players().unwrap().remove_player(0).is_ok());
+    }
+
+    #[test]
+    fn move_player() {
+        let new_pos = Position::new(0, 0);
+        match new_players().unwrap().move_player(0, new_pos) {
+            MoveResult::Moved(player) => assert!(player.get_position() == new_pos),
+            _ => panic!("Wrong result"),
+        };
+    }
+
+    #[test]
+    fn new_game_ok() {
+        assert!(new_game().is_ok());
+    }
+
+    #[test]
+    fn game_actions() {
+        let mut game = new_game().unwrap();
+        assert!(game.shift_tiles(SideIndex::new(Side::Top, 1)).is_ok());
+        assert!(game.remove_player(0).is_ok());
+        assert!(game.move_player(1, Position::new(0, 6)).is_ok());
     }
 }

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -34,13 +34,17 @@ pub struct Position {
 }
 
 pub enum MoveResult<'a> {
-    Won(PlayerId),
     Moved(&'a mut Player),
+    Won(PlayerId),
+    InvalidPlayer,
 }
 
 impl Players {
-    pub fn new(mut ids: Vec<PlayerId>, items_per_player: usize, board: &Board) -> Self {
-        assert!(ids.len() > 1);
+    pub fn new(mut ids: Vec<PlayerId>, items_per_player: usize, board: &Board) -> Option<Self> {
+        if ids.len() < 2 {
+            return None;
+        }
+
         ids.sort();
 
         let player_turn = *ids.first().unwrap();
@@ -65,21 +69,30 @@ impl Players {
 
         assert!(items.is_empty());
 
-        Self {
+        Some(Self {
             players,
             player_turn,
-        }
+        })
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Player> {
         self.players.values_mut()
     }
 
-    pub fn remove_player(&mut self, player_id: PlayerId) {
-        self.players.remove(&player_id);
+    pub fn remove_player(&mut self, player_id: PlayerId) -> Result<Option<PlayerId>, ()> {
+        if self.players.remove(&player_id).is_none() {
+            return Err(());
+        }
+
+        if self.players.len() == 1 {
+            return Ok(self.players.first_key_value().map(|(id, _)| *id));
+        }
+
         if player_id == self.player_turn {
             self.next_player_turn();
         }
+
+        Ok(None)
     }
 
     pub fn next_player_turn(&mut self) {
@@ -87,24 +100,23 @@ impl Players {
             .players
             .range(self.player_turn..)
             .next()
-            .or_else(|| self.players.iter().next())
+            .or_else(|| self.players.first_key_value())
             .map(|(id, _)| *id)
-            .unwrap_or_default();
+            .unwrap();
     }
 
     pub fn move_player(&mut self, player_id: PlayerId, position: Position) -> MoveResult {
-        let player = self.get_mut(player_id);
-        player.set_position(position);
+        if let Some(player) = self.players.get_mut(&player_id) {
+            player.set_position(position);
 
-        if player.get_next_to_collect().is_none() && player.is_at_start() {
-            MoveResult::Won(player_id)
+            if player.get_next_to_collect().is_none() && player.is_at_start() {
+                MoveResult::Won(player_id)
+            } else {
+                MoveResult::Moved(player)
+            }
         } else {
-            MoveResult::Moved(player)
+            MoveResult::InvalidPlayer
         }
-    }
-
-    fn get_mut(&mut self, player_id: PlayerId) -> &mut Player {
-        self.players.get_mut(&player_id).unwrap()
     }
 }
 
@@ -132,13 +144,12 @@ impl Player {
     }
 
     pub fn set_position(&mut self, position: Position) {
-        assert!(position != self.position);
         self.position = position;
     }
 
     pub fn try_collect_item(&mut self, board: &Board) {
         let next = self.get_next_to_collect();
-        if next.is_some() && next == board.get_item(self.position) {
+        if next.is_some() && next == board[self.position].get_item() {
             self.collected.push(self.to_collect.pop().unwrap());
         }
     }

--- a/game-core/game/src/tile.rs
+++ b/game-core/game/src/tile.rs
@@ -54,7 +54,7 @@ pub struct FreeTile {
 
 /// The index always goes from left to right or from top to bottom.
 #[ts_interop]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SideIndex {
     side: Side,
     index: usize,
@@ -101,6 +101,10 @@ impl FreeTile {
         }
     }
 
+    pub fn get_side_index(&self) -> Option<SideIndex> {
+        self.side_with_index
+    }
+
     pub fn set_rotation(&mut self, rotation: Rotation) {
         self.tile.rotation = rotation;
     }
@@ -115,6 +119,10 @@ impl FreeTile {
 }
 
 impl SideIndex {
+    pub fn new(side: Side, index: usize) -> Self {
+        Self { side, index }
+    }
+
     pub fn get_side(&self) -> Side {
         self.side
     }


### PR DESCRIPTION
This PR adds error handling to the `game` crate and modifies `GameCore` to return a result type of the current game sate state or a string describing the error that occurred.

The PR also adds test for the `game` crate, testing the functionality of its various components.

Depends on: #18 