### PR TITLE
Update board coordinate system

### DIFF
--- a/game-core/game/src/board.rs
+++ b/game-core/game/src/board.rs
@@ -125,7 +125,7 @@ impl Board {
         if x >= self.side_length || y >= self.side_length {
             return None;
         }
-        self.tiles.get(x * self.side_length + y)
+        self.tiles.get(x + y * self.side_length)
     }
 
     pub fn rotate_free_tile(&mut self, rotation: Rotation) {

--- a/game-core/game/src/player.rs
+++ b/game-core/game/src/player.rs
@@ -172,9 +172,9 @@ impl Position {
 fn get_start_position(index: usize, side_length: usize) -> Position {
     match index % 4 {
         0 => Position::new(0, 0),
-        1 => Position::new(0, side_length - 1),
+        1 => Position::new(side_length - 1, 0),
         2 => Position::new(side_length - 1, side_length - 1),
-        _ => Position::new(side_length - 1, 0),
+        _ => Position::new(0, side_length - 1),
     }
 }
 


### PR DESCRIPTION
This PR updates the board in the backend to use the following coordinate system:
```
o ––> x
|
V
y
```
It also changes the starting locations of the players to be in clockwise order according to this system.