### PR TITLE
Add a Result and Option type to frontend

### DIFF
--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -19,6 +19,7 @@ import GameSettings from "./GameSettings.vue";
 import { NButton } from "naive-ui";
 import { groupBy } from "@/array-utils";
 import { PlayerColors } from "@/players";
+import { fromNullable } from "@/result";
 
 const gameSettings = defineModel<GameStartSettings>("startSettings", {
   required: true,
@@ -47,31 +48,30 @@ interface TileData {
   y: number;
 }
 
-const tileSize = computed(() => {
-  const board = props.board;
-  if (board === null) {
-    return "0";
-  }
-  return 100 / board.side_length + "cqw";
-});
+const tileSize = computed(() =>
+  fromNullable(props.board)
+    .map((b) => 100 / b.side_length + "cqw")
+    .unwrapOr("0")
+);
 
-const tilesMap = computed(() => {
-  const board = props.board;
-  if (board === null) {
-    return new Map<number, TileData>();
-  }
-
-  return new Map(
-    board.tiles.map((tile, index) => [
-      tile.id,
-      {
-        tile,
-        x: index % board.side_length,
-        y: Math.floor(index / board.side_length),
-      },
-    ])
-  );
-});
+const tilesMap = computed(() =>
+  fromNullable(props.board)
+    .map((board) =>
+      board.tiles.map(
+        (tile, index) =>
+          [
+            tile.id,
+            {
+              tile,
+              x: index % board.side_length,
+              y: Math.floor(index / board.side_length),
+            } as TileData,
+          ] as const
+      )
+    )
+    .map((tiles) => new Map(tiles))
+    .unwrapOr(new Map<number, TileData>())
+);
 
 interface SideArrow {
   id: string;

--- a/src/game.ts
+++ b/src/game.ts
@@ -33,12 +33,7 @@ export function useGame() {
 
   const core = new GameCore(10);
 
-  {
-    const state = storage.load();
-    if (state) {
-      setGame(state);
-    }
-  }
+  storage.load().map((state) => setGame(state));
 
   const observer = {
     next(g: Game) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,8 +7,10 @@ import init, {
   type Rotation,
   type SideIndex,
   type Game,
-} from "../game-core/pkg";
-import { useLocalStorage } from "./local-storage";
+  type Result as ActionResult,
+} from "game-core/pkg";
+import { useLocalStorage } from "@/local-storage";
+import { Result } from "@/result";
 
 await init();
 
@@ -33,37 +35,34 @@ export function useGame() {
 
   const core = new GameCore(10);
 
-  storage.load().map((state) => setGame(state));
+  storage.load().map(state => setGame(state));
 
-  const observer = {
-    next(g: Game) {
+  function handleResult(result: ActionResult<Game, string>) {
+    Result.fromSplitResult(result).map(g => {
       game.value = g;
       saveState();
-    },
-    error(err: string) {
-      alert(err);
-    },
-  };
+    }).mapErr(alert);
+  }
 
   function startGame(settings: GameStartSettings) {
     reset();
-    core.start_game(settings).subscribe(observer);
+    handleResult(core.start_game(settings));
   }
 
   function rotate_free_tile(rotation: Rotation) {
-    core.rotate_free_tile(rotation).subscribe(observer);
+    handleResult(core.rotate_free_tile(rotation));
   }
 
   function shiftTiles(side_index: SideIndex) {
-    core.shift_tiles(side_index).subscribe(observer);
+    handleResult(core.shift_tiles(side_index));
   }
 
   function removePlayer(id: PlayerId) {
-    core.remove_player(id).subscribe(observer);
+    handleResult(core.remove_player(id));
   }
 
   function movePlayer(id: PlayerId, x: number, y: number) {
-    core.move_player(id, { x, y }).subscribe(observer);
+    handleResult(core.move_player(id, { x, y }));
   }
 
   function setGame(g: Game) {
@@ -78,7 +77,7 @@ export function useGame() {
   }
 
   function undoMove() {
-    core.undo_move().subscribe(observer);
+    handleResult(core.undo_move());
   }
 
   function finishGame() {

--- a/src/local-storage.ts
+++ b/src/local-storage.ts
@@ -1,4 +1,5 @@
 import { JsonSerializer } from "json-safe-stringify";
+import { None, Some, type Option } from "./result";
 
 export function useLocalStorage<T>() {
   const version = 1;
@@ -13,7 +14,7 @@ export function useLocalStorage<T>() {
     localStorage.setItem(key, serializer.stringify({ version, state }));
   };
 
-  const load = () => {
+  const load = (): Option<T> => {
     const entry = localStorage.getItem(key);
     if (entry !== null) {
       try {
@@ -22,11 +23,11 @@ export function useLocalStorage<T>() {
           state: T;
         };
         if (parsed.version === version) {
-          return parsed.state;
+          return Some(parsed.state);
         }
       } catch (e) {}
     }
-    return null;
+    return None();
   };
 
   return {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,121 @@
+export function Ok<T, E = never>(value: T): Result<T, E> {
+  return Result.ok(value);
+}
+export function Err<T, E>(error: E): Result<T, E> {
+  return Result.err(error);
+}
+
+export function Some<T>(value: T): Option<T> {
+  return Result.ok(value);
+}
+export function None<T>(): Option<T> {
+  return Result.err("NoneError");
+}
+export function fromNullable<T>(value: T | null | undefined): Option<T> {
+  if (value === null || value === undefined) {
+    return None();
+  }
+  return Some(value);
+}
+
+export type NoneError = "NoneError";
+export type Option<T> = Result<T, NoneError>;
+
+export type SplittedResult<T, E> =
+  | {
+      t: "ok";
+      v: T;
+    }
+  | {
+      t: "err";
+      v: E;
+    };
+
+export class Result<T, E> {
+  constructor(private _value: T | E, private _isOk: boolean) {}
+  static ok<T, E = never>(value: T): Result<T, E> {
+    return new Result<T, E>(value, true);
+  }
+  static err<T, E>(error: E): Result<T, E> {
+    return new Result<T, E>(error, false);
+  }
+
+  isErr(): boolean {
+    return !this._isOk;
+  }
+  isOk(): boolean {
+    return this._isOk;
+  }
+
+  split(): SplittedResult<T, E> {
+    if (this.isOk()) {
+      return { t: "ok", v: this._value as T };
+    }
+    return { t: "err", v: this._value as E };
+  }
+
+  unwrap(): T {
+    if (this.isErr()) {
+      throw new Error("Called unwrap on an error value");
+    }
+    return this._value as T;
+  }
+
+  unwrapErr(): E {
+    if (this.isOk()) {
+      throw new Error("Called unwrapErr on an ok value");
+    }
+    return this._value as E;
+  }
+
+  map<U>(fn: (value: T) => U): Result<U, E> {
+    if (this.isErr()) {
+      return Result.err(this._value as E);
+    }
+    return Result.ok(fn(this._value as T));
+  }
+
+  mapErr<U>(fn: (error: E) => U): Result<T, U> {
+    if (this.isOk()) {
+      return Result.ok(this._value as T);
+    }
+    return Result.err(fn(this._value as E));
+  }
+
+  and<U>(result: Result<U, E>): Result<U, E> {
+    if (this.isOk()) {
+      return result;
+    }
+    return Result.err(this._value as E);
+  }
+
+  andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E> {
+    if (this.isOk()) {
+      return fn(this._value as T);
+    }
+    return Result.err(this._value as E);
+  }
+
+  unwrapOr<U>(value: U): T | U {
+    if (this.isOk()) {
+      return this._value as T;
+    }
+    return value;
+  }
+
+  static all<T, E>(results: Result<T, E>[]): Result<T[], E[]> {
+    let errors: E[] = [];
+    let values: T[] = [];
+    for (let result of results) {
+      if (result.isOk()) {
+        values.push(result.unwrap());
+      } else {
+        errors.push(result.unwrapErr());
+      }
+    }
+    if (errors.length > 0) {
+      return Result.err(errors);
+    }
+    return Result.ok(values);
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
This PR adds typescript implementations of the rust `Result` and `Option` types to improve interoperability with the return values of the backend. 