### PR TITLE
Refactor `GameCore` to return `Result`s

### DIFF
--- a/game-core/Cargo.lock
+++ b/game-core/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "log",
  "serde",
  "serde-wasm-bindgen",
+ "tsify",
  "wasm-bindgen",
 ]
 

--- a/game-core/wasm/Cargo.toml
+++ b/game-core/wasm/Cargo.toml
@@ -14,4 +14,5 @@ game = { path = "../game", features = ["wasm"] }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.5"
+tsify =  { version = "0.4", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2"

--- a/game-core/wasm/src/result.rs
+++ b/game-core/wasm/src/result.rs
@@ -1,0 +1,18 @@
+use serde::Serialize;
+use tsify::Tsify;
+
+#[derive(Tsify, Serialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct Result<T, E> {
+    ok: bool,
+    #[tsify(type = "T | E")]
+    value: std::result::Result<T, E>,
+}
+
+impl<T: Serialize, E: Serialize> From<std::result::Result<T, E>> for Result<T, E> {
+    fn from(value: std::result::Result<T, E>) -> Self {
+        let ok = value.is_ok();
+
+        Self { ok, value }
+    }
+}


### PR DESCRIPTION
This PR refactors the mutating functions in `GameCore` to return a `Result` type.
The advantage of this approach is to allow for generating Typescript interfaces to allow better type safety in the frontend.