### PR TITLE
Fix serialization of `Result`

### DIFF
--- a/game-core/wasm/src/result.rs
+++ b/game-core/wasm/src/result.rs
@@ -3,16 +3,17 @@ use tsify::Tsify;
 
 #[derive(Tsify, Serialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct Result<T, E> {
-    ok: bool,
-    #[tsify(type = "T | E")]
-    value: std::result::Result<T, E>,
+#[serde(tag = "type", content = "value")]
+pub enum Result<T, E> {
+    Ok(T),
+    Err(E),
 }
 
-impl<T: Serialize, E: Serialize> From<std::result::Result<T, E>> for Result<T, E> {
+impl<T, E> From<std::result::Result<T, E>> for Result<T, E> {
     fn from(value: std::result::Result<T, E>) -> Self {
-        let ok = value.is_ok();
-
-        Self { ok, value }
+        match value {
+            Ok(ok) => Result::Ok(ok),
+            Err(err) => Result::Err(err),
+        }
     }
 }


### PR DESCRIPTION
This PR fixes `Result` such that it is serialized into the correct Typescript type.